### PR TITLE
Add synchronous implementation Arp.Lookup()

### DIFF
--- a/src/ArpLookup/ArpLookup.csproj
+++ b/src/ArpLookup/ArpLookup.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>ArpLookup</PackageId>
+    <Authors>Georg Jung, Henrik Sozzi</Authors>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
I've added synchronous implementation of the required methods to create a synchronous Lookup() method.
I've also created a TryLookup() method that returns a bool that indicate if the lookup was successful or not, returning the mac in the out argument, as per .net standard implementation. It's handy :)