### PR TITLE
Ensure breaking changes without major version increment lead to errors while packaging

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.301",
+    "version": "6.0.100-preview.5.21302.13",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/src/ArpLookup/ArpLookup.csproj
+++ b/src/ArpLookup/ArpLookup.csproj
@@ -19,4 +19,9 @@
     <None Include="../../doc/logo-nuget.png" Pack="true" PackagePath="/icon.png" />
   </ItemGroup>
 
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.5.21302.8" />
+  <PropertyGroup>
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This requires .net 6, which is in preview. Thus, this is a draft until the required tooling is released.

See https://devblogs.microsoft.com/dotnet/package-validation/